### PR TITLE
Corrected the typos in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 ## Install dependencies
 
-1. Do the following before installing the dependencies found in `requirements.txt` file because of current challenges installing `onnxruntime` through `pip install onnxruntime`. 
+1. Do the following before installing the dependencies found in the `requirements.txt` file because of current challenges installing `onnxruntime` through `pip install onnxruntime`. 
 
     - For MacOS users, a workaround is to first install `onnxruntime` dependency for `chromadb` using:
 
     ```python
      conda install onnxruntime -c conda-forge
     ```
-    See this [thread](https://github.com/microsoft/onnxruntime/issues/11037) for additonal help if needed. 
+    See this [thread](https://github.com/microsoft/onnxruntime/issues/11037) for additional help if needed. 
 
-     - For Windows users, follow the guide [here](https://github.com/bycloudai/InstallVSBuildToolsWindows?tab=readme-ov-file) to install the Microsoft C++ Build Tools. Be sure to follow through to the last step to set the enviroment variable path.
+     - For Windows users, follow the guide [here](https://github.com/bycloudai/InstallVSBuildToolsWindows?tab=readme-ov-file) to install the Microsoft C++ Build Tools. Be sure to follow through to the last step to set the environment variable path.
 
 
-2. Now run this command to install dependenies in the `requirements.txt` file. 
+2. Now run this command to install dependencies in the `requirements.txt` file. 
 
 ```python
 pip install -r requirements.txt
 ```
 
-3. Install markdown depenendies with: 
+3. Install markdown dependencies with: 
 
 ```python
 pip install "unstructured[md]"


### PR DESCRIPTION
This PR would fix small typos present in the readme.md file.

Corrected:

1. `additonal` to `additional`
2.  `dependenies` to `dependencies`
3.  `depenendies` to `dependencies`
4. `enviroment` to `environment`
5. `requirements.txt` to `the requirements.txt`