### PR TITLE
Resolve Issue #14, update deprecation of BaseChatModel.predict, update setup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,36 @@
     ```python
      conda install onnxruntime -c conda-forge
     ```
-    See this [thread](https://github.com/microsoft/onnxruntime/issues/11037) for additonal help if needed. 
+    See this [thread](https://github.com/microsoft/onnxruntime/issues/11037) for additional help if needed. 
 
-     - For Windows users, follow the guide [here](https://github.com/bycloudai/InstallVSBuildToolsWindows?tab=readme-ov-file) to install the Microsoft C++ Build Tools. Be sure to follow through to the last step to set the enviroment variable path.
+     - For Windows users, follow the guide [here](https://github.com/bycloudai/InstallVSBuildToolsWindows?tab=readme-ov-file) to install the Microsoft C++ Build Tools. Be sure to follow through to the last step to set the environment variable path.
 
 
-2. Now run this command to install dependenies in the `requirements.txt` file. 
+2. Now run this command to install dependencies in the `requirements.txt` file. 
 
 ```python
 pip install -r requirements.txt
 ```
 
-3. Install markdown depenendies with: 
+3. Install markdown dependencies with: 
 
 ```python
 pip install "unstructured[md]"
 ```
+
+4. Install NLTK tokenizers
+
+```
+python -m nltk.downloader tokenizers
+```
+
+5. Generate an [OpenAI](https://platform.openai.com/settings) API key and save it to the `.env` file
+
+```
+OPENAI_API_KEY=
+```
+
+For the API key to function correctly, you will need to put some money on your account. The minimum of 5$ will suffice.
 
 ## Create database
 
@@ -41,7 +55,5 @@ Query the Chroma DB.
 ```python
 python query_data.py "How does Alice meet the Mad Hatter?"
 ```
-
-> You'll also need to set up an OpenAI account (and set the OpenAI key in your environment variable) for this to work.
 
 Here is a step-by-step tutorial video: [RAG+Langchain Python Project: Easy AI/Chat For Your Docs](https://www.youtube.com/watch?v=tcqEUSNCn8I&ab_channel=pixegami).

--- a/query_data.py
+++ b/query_data.py
@@ -4,6 +4,16 @@ from langchain_community.vectorstores import Chroma
 from langchain_openai import OpenAIEmbeddings
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
+from dotenv import load_dotenv
+import openai
+import os
+
+# Load environment variables. Assumes that project contains .env file with API keys
+load_dotenv()
+#---- Set OpenAI API key 
+# Change environment variable name from "OPENAI_API_KEY" to the name given in 
+# your .env file.
+openai.api_key = os.environ['OPENAI_API_KEY']
 
 CHROMA_PATH = "chroma"
 
@@ -41,10 +51,10 @@ def main():
     print(prompt)
 
     model = ChatOpenAI()
-    response_text = model.predict(prompt)
+    response_text = model.invoke(prompt)
 
     sources = [doc.metadata.get("source", None) for doc, _score in results]
-    formatted_response = f"Response: {response_text}\nSources: {sources}"
+    formatted_response = f"Response: {response_text.content}\nSources: {sources}"
     print(formatted_response)
 
 


### PR DESCRIPTION
- fix: resolves issue #14 
- fix: typos first mentioned in PR: #11 
- fix: add missing `OPENAI_API_KEY` setup in `query_data.py` as mentioned in PR: #13 
- fix: update the deprecation of the method `BaseChatModel.predict` as mentioned in PR: #15 
- feature: update the setup process to include downloading on missing NLTK tokenizers, setup of local `.env` file, and the requirement of OpenAI needing money on your account